### PR TITLE
コードベースを機能別モジュールに分離してリファクタリング

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Fetching and File Generation
 ```bash
-# Run the fetcher to generate calendar files
+# Run the fetcher to generate calendar files (uses tsx, faster for development)
 npm run fetch
 
 # Development mode (same as fetch)
 npm run dev
 
-# Build TypeScript and run compiled version
+# Build with esbuild and run compiled version (single bundled file)
 npm start
 
-# Build TypeScript only
+# Build TypeScript only (creates dist/fetcher.js)
 npm run build
 ```
 
@@ -27,41 +27,65 @@ npm install
 
 ## Architecture
 
-This is a web fetcher for M-League (Japanese professional mahjong league) schedules that generates calendar files for subscription.
+This is a web fetcher for M-League (Japanese professional mahjong league) schedules that generates iCal calendar files for subscription.
 
-### Core Components
+### Module Structure
 
-1. **Fetcher (`src/fetcher.ts`)**
-   - Fetches M-League official website for seasons 2025-2026 (September to May)
-   - Fixed URLs: `https://m-league.jp/games/?mly={year}&mlm={month}#schedule`
-   - Periods: 2025/9 through 2026/5 (hardcoded in `periods` array)
-   - Uses native fetch API with regex parsing for HTML content
+The codebase follows a modular architecture with clear separation of concerns:
 
-2. **Output Generation**
-   - Creates both JSON and iCal (.ics) formats
-   - Files are saved to both root directory and `docs/` folder
-   - `docs/` folder is for GitHub Pages hosting
+```
+src/
+├── types/schedule.ts          # Type definitions (Schedule, Period)
+├── config.ts                  # Configuration (periods, selectors, regex patterns)
+├── utils/
+│   ├── calendar-utils.ts      # UID generation, datetime formatting
+│   └── file-utils.ts          # File I/O operations
+├── parsers/
+│   └── html-parser.ts         # HTML parsing logic (regex-based)
+├── generators/
+│   └── ical-generator.ts      # iCalendar format generation
+├── scrapers/
+│   └── m-league-scraper.ts    # MLeagueScraper class for fetching
+└── fetcher.ts                 # Entry point (35 lines, orchestrates modules)
+```
 
-3. **iCal Format Specifications**
-   - Event title format: `[Team1][Team2][Team3][Team4]`
-   - Time: 19:00-24:00 JST (Japan Standard Time)
-   - Location: url || ABEMA TV
-   - Calendar name: "Mリーグ 2025-26 スケジュール"
+### Data Flow
 
-### Key Selectors
-- Schedule list items: `.p-gamesSchedule2__list`
-- Date element: `.p-gamesSchedule2__data`
-- Team logos: `.p-gamesSchedule2__logos img` (alt attribute contains team name)
+1. **Scraper** (`MLeagueScraper`) fetches HTML from M-League website for each month (2025/9 through 2026/5)
+2. **Parser** (`html-parser.ts`) extracts schedule data using regex patterns
+3. **Generator** (`ical-generator.ts`) converts schedules to iCalendar format
+4. **File Utils** saves output to `docs/m-league-schedule.ics` for GitHub Pages
 
-### Output Files
-- `docs/m-league-schedule.ics` - For GitHub Pages subscription URL
-- `docs/m-league-schedule.json` - For GitHub Pages JSON access
+### Key Configuration (`src/config.ts`)
+
+All configuration is centralized in `M_LEAGUE_CONFIG`:
+- **Periods**: 2025/9 through 2026/5 (hardcoded array)
+- **Selectors**: CSS class names for HTML parsing
+- **Regex Patterns**: For extracting dates, teams, URLs from HTML
+- **Calendar Settings**: Timezone, event times (19:00-24:00 JST), default location
+
+### iCal Format Specifications
+
+- Event title format: `[Team1][Team2][Team3][Team4]`
+- Time: 19:00-24:00 JST (Japan Standard Time)
+- Location: Game URL or `https://abema.tv/now-on-air/mahjong`
+- Calendar name: "Mリーグ 2025-26 スケジュール"
+- UID: Deterministic hash based on date + team names (SHA-256, 12 chars)
+- Includes alarm at event start time
+
+### Build System
+
+- **Development**: Uses `tsx` for direct TypeScript execution (no build step)
+- **Production**: Uses `esbuild` to bundle all modules into single `dist/fetcher.js` (7.8kb, ~3ms build)
+- **TypeScript**: `moduleResolution: "bundler"` - no `.js` extensions needed in imports
 
 ### GitHub Pages URL
+
 When deployed: `https://suzuryo.github.io/m-league-ical/m-league-schedule.ics`
 
 ## Important Notes
 
-- The fetcher targets specific CSS selectors on the M-League website. If the website structure changes, update the selectors in `scrapeMLeagueScheduleForMonth()`.
-- Months without published schedules (e.g., April, May) are handled gracefully with a 5-second timeout.
+- CSS selectors and regex patterns are defined in `src/config.ts`. If the M-League website structure changes, update them there.
+- Months without published schedules (e.g., April, May) return empty arrays gracefully.
 - Each game involves exactly 4 teams competing simultaneously.
+- The scraper uses native `fetch()` API (no external HTTP libraries).

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@eslint/js": "9.36.0",
         "@types/node": "24.5.2",
+        "esbuild": "0.25.10",
         "eslint": "9.36.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-prettier": "5.5.4",
@@ -26,9 +27,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
       "cpu": [
         "ppc64"
       ],
@@ -43,9 +44,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
       "cpu": [
         "arm"
       ],
@@ -60,9 +61,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +78,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +95,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -111,9 +112,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
       "cpu": [
         "x64"
       ],
@@ -128,9 +129,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
       "cpu": [
         "arm64"
       ],
@@ -145,9 +146,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
       "cpu": [
         "x64"
       ],
@@ -162,9 +163,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
       "cpu": [
         "arm"
       ],
@@ -179,9 +180,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
       "cpu": [
         "arm64"
       ],
@@ -196,9 +197,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
       "cpu": [
         "ia32"
       ],
@@ -213,9 +214,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
       "cpu": [
         "loong64"
       ],
@@ -230,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
       "cpu": [
         "mips64el"
       ],
@@ -247,9 +248,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
       "cpu": [
         "ppc64"
       ],
@@ -264,9 +265,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
       "cpu": [
         "riscv64"
       ],
@@ -281,9 +282,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
       "cpu": [
         "s390x"
       ],
@@ -298,9 +299,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
       "cpu": [
         "x64"
       ],
@@ -315,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
       "cpu": [
         "arm64"
       ],
@@ -332,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
       "cpu": [
         "x64"
       ],
@@ -349,9 +350,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
       "cpu": [
         "arm64"
       ],
@@ -366,9 +367,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
       "cpu": [
         "x64"
       ],
@@ -383,9 +384,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
       "cpu": [
         "arm64"
       ],
@@ -400,9 +401,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
       "cpu": [
         "x64"
       ],
@@ -417,9 +418,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
       "cpu": [
         "arm64"
       ],
@@ -434,9 +435,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
       "cpu": [
         "ia32"
       ],
@@ -451,9 +452,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
       "cpu": [
         "x64"
       ],
@@ -1201,9 +1202,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1214,32 +1215,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/fetcher.js",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "esbuild src/fetcher.ts --bundle --platform=node --format=esm --outfile=dist/fetcher.js --external:node:*",
+    "typecheck": "tsc --noEmit",
     "fetch": "tsx src/fetcher.ts",
     "start": "npm run build && node dist/fetcher.js",
     "dev": "tsx src/fetcher.ts",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/js": "9.36.0",
     "@types/node": "24.5.2",
+    "esbuild": "0.25.10",
     "eslint": "9.36.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.4",

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,12 @@ export const M_LEAGUE_CONFIG = {
     timezone: 'Asia/Tokyo',
     eventStartTime: '190000', // 19:00:00
     eventEndTime: '240000', // 24:00:00
+    // Fallback URL used as the event location when schedule.url is undefined.
     defaultLocation: 'https://abema.tv/now-on-air/mahjong',
+    description: {
+      prefix: '対戦チーム:',
+      teamBullet: '・',
+    },
   },
 
   selectors: {
@@ -29,6 +34,11 @@ export const M_LEAGUE_CONFIG = {
   },
 
   regex: {
+    // Matches a single <li> element with class "p-gamesSchedule2__list" and captures its inner HTML.
+    // Breakdown of the regex:
+    //   - <li class="p-gamesSchedule2__list[^"]*"[^>]*> : Matches the opening <li> tag with the specific class, allowing for additional classes/attributes.
+    //   - ([\s\S]*?) : Non-greedy capture of all content inside the <li> (including newlines).
+    //   - (?=<li class="p-gamesSchedule2__list|<\/ul>) : Lookahead to stop at the next <li> with the same class or the closing </ul>.
     listItem:
       /<li class="p-gamesSchedule2__list[^"]*"[^>]*>([\s\S]*?)(?=<li class="p-gamesSchedule2__list|<\/ul>)/g,
     date: /<p class="p-gamesSchedule2__data">(\d+)<span[^>]*>\/[^<]*<\/span>(\d+)/,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export const M_LEAGUE_CONFIG = {
     eventStartTime: '190000', // 19:00:00
     eventEndTime: '240000', // 24:00:00
     // Fallback URL used as the event location when schedule.url is undefined.
+    // Fallback URL used as the event location when schedule.url is undefined.
     defaultLocation: 'https://abema.tv/now-on-air/mahjong',
     description: {
       prefix: '対戦チーム:',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,38 @@
+import type { Period } from './types/schedule'
+
+export const M_LEAGUE_CONFIG = {
+  baseUrl: 'https://m-league.jp/games/',
+
+  periods: [
+    { year: 2025, month: 9 },
+    { year: 2025, month: 10 },
+    { year: 2025, month: 11 },
+    { year: 2025, month: 12 },
+    { year: 2026, month: 1 },
+    { year: 2026, month: 2 },
+    { year: 2026, month: 3 },
+    { year: 2026, month: 4 },
+    { year: 2026, month: 5 },
+  ] as Period[],
+
+  calendar: {
+    name: 'Mリーグ 2025-26 スケジュール',
+    timezone: 'Asia/Tokyo',
+    eventStartTime: '190000', // 19:00:00
+    eventEndTime: '240000', // 24:00:00
+    defaultLocation: 'https://abema.tv/now-on-air/mahjong',
+  },
+
+  selectors: {
+    listClass: 'p-gamesSchedule2__list',
+    dateClass: 'p-gamesSchedule2__data',
+  },
+
+  regex: {
+    listItem:
+      /<li class="p-gamesSchedule2__list[^"]*"[^>]*>([\s\S]*?)(?=<li class="p-gamesSchedule2__list|<\/ul>)/g,
+    date: /<p class="p-gamesSchedule2__data">(\d+)<span[^>]*>\/[^<]*<\/span>(\d+)/,
+    team: /<img[^>]*alt="([^"]+)"[^>]*>/g,
+    url: /<a href="([^"]+)"/,
+  },
+} as const

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ export const M_LEAGUE_CONFIG = {
     //   - <li class="p-gamesSchedule2__list[^"]*"[^>]*> : Matches the opening <li> tag with the specific class, allowing for additional classes/attributes.
     //   - ([\s\S]*?) : Non-greedy capture of all content inside the <li> (including newlines).
     //   - (?=<li class="p-gamesSchedule2__list|<\/ul>) : Lookahead to stop at the next <li> with the same class or the closing </ul>.
+    // Matches a single <li> element with class "p-gamesSchedule2__list" and captures its inner HTML.
+    // Breakdown of the regex:
+    //   - <li class="p-gamesSchedule2__list[^"]*"[^>]*> : Matches the opening <li> tag with the specific class, allowing for additional classes/attributes.
+    //   - ([\s\S]*?) : Non-greedy capture of all content inside the <li> (including newlines).
+    //   - (?=<li class="p-gamesSchedule2__list|<\/ul>) : Lookahead to stop at the next <li> with the same class or the closing </ul>.
     listItem:
       /<li class="p-gamesSchedule2__list[^"]*"[^>]*>([\s\S]*?)(?=<li class="p-gamesSchedule2__list|<\/ul>)/g,
     date: /<p class="p-gamesSchedule2__data">(\d+)<span[^>]*>\/[^<]*<\/span>(\d+)/,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,191 +1,14 @@
-import { createHash } from 'node:crypto'
-import { writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-
-import { parseISO } from 'date-fns'
-
-interface Schedule {
-  date: string
-  teams: string[]
-  url?: string
-}
-
-async function scrapeMLeagueScheduleForMonth(
-  year: number,
-  month: number,
-): Promise<Schedule[]> {
-  const url = `https://m-league.jp/games/?mly=${year}&mlm=${month}#schedule`
-
-  console.log(`Fetching schedule from: ${url}`)
-
-  try {
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-
-    const html = await response.text()
-
-    // Check if schedule data exists
-    if (!html.includes('p-gamesSchedule2__list')) {
-      console.log(`  No schedule data available for ${year}/${month}`)
-      return []
-    }
-
-    const schedules: Schedule[] = []
-
-    // Parse schedule items - need to be careful with nested li tags
-    const listRegex =
-      /<li class="p-gamesSchedule2__list">([\s\S]*?)(?=<li class="p-gamesSchedule2__list">|<\/ul>)/g
-    let listMatch
-
-    while ((listMatch = listRegex.exec(html)) !== null) {
-      const listContent = listMatch[0]
-
-      // Extract date
-      const dateMatch = listContent.match(
-        /<p class="p-gamesSchedule2__data">(\d+)<span[^>]*>\/[^<]*<\/span>(\d+)/,
-      )
-      if (!dateMatch) continue
-
-      const monthStr = dateMatch[1].padStart(2, '0')
-      const dayStr = dateMatch[2].padStart(2, '0')
-      const formattedDate = `${year}-${monthStr}-${dayStr}`
-
-      // Extract teams from img alt attributes
-      const teams: string[] = []
-      const teamRegex = /<img[^>]*alt="([^"]+)"[^>]*>/g
-      let teamMatch
-
-      while ((teamMatch = teamRegex.exec(listContent)) !== null) {
-        const teamName = teamMatch[1].trim()
-        if (teamName && !teamName.includes('M.League')) {
-          teams.push(teamName)
-        }
-      }
-
-      if (teams.length === 0) continue
-
-      // Extract URL
-      const urlMatch = listContent.match(/<a href="([^"]+)"/)
-      const gameUrl = urlMatch ? urlMatch[1] : undefined
-
-      schedules.push({
-        date: formattedDate,
-        teams: teams,
-        url: gameUrl,
-      })
-    }
-
-    return schedules
-  } catch (error) {
-    console.log(`  Error fetching schedule for ${year}/${month}:`, error)
-    return []
-  }
-}
-
-async function scrapeAllMLeagueSchedules(): Promise<Schedule[]> {
-  const allSchedules: Schedule[] = []
-
-  const periods = [
-    { year: 2025, month: 9 },
-    { year: 2025, month: 10 },
-    { year: 2025, month: 11 },
-    { year: 2025, month: 12 },
-    { year: 2026, month: 1 },
-    { year: 2026, month: 2 },
-    { year: 2026, month: 3 },
-    { year: 2026, month: 4 },
-    { year: 2026, month: 5 },
-  ]
-
-  for (const period of periods) {
-    const monthSchedules = await scrapeMLeagueScheduleForMonth(
-      period.year,
-      period.month,
-    )
-    allSchedules.push(...monthSchedules)
-    console.log(
-      `  Found ${monthSchedules.length} matches for ${period.year}/${period.month}`,
-    )
-  }
-
-  return allSchedules
-}
-
-function generateICalendar(schedules: Schedule[]): string {
-  const icalLines: string[] = []
-
-  icalLines.push('BEGIN:VCALENDAR')
-  icalLines.push('VERSION:2.0')
-  icalLines.push('PRODID:-//M-League Schedule//JP')
-  icalLines.push('CALSCALE:GREGORIAN')
-  icalLines.push('METHOD:PUBLISH')
-  icalLines.push('X-WR-CALNAME:Mリーグ 2025-26 スケジュール')
-  icalLines.push('X-WR-TIMEZONE:Asia/Tokyo')
-
-  icalLines.push('BEGIN:VTIMEZONE')
-  icalLines.push('TZID:Asia/Tokyo')
-  icalLines.push('BEGIN:STANDARD')
-  icalLines.push('DTSTART:19700101T000000')
-  icalLines.push('TZOFFSETFROM:+0900')
-  icalLines.push('TZOFFSETTO:+0900')
-  icalLines.push('END:STANDARD')
-  icalLines.push('END:VTIMEZONE')
-
-  schedules.forEach((schedule) => {
-    const date = parseISO(schedule.date)
-    const startYear = date.getFullYear()
-    const startMonth = String(date.getMonth() + 1).padStart(2, '0')
-    const startDay = String(date.getDate()).padStart(2, '0')
-
-    // Generate deterministic UID based on date and team names (sorted for consistency)
-    const teamHash = createHash('sha256')
-      .update(schedule.date + [...schedule.teams].sort().join(','))
-      .digest('hex')
-      .substring(0, 12)
-    const uid = `${schedule.date}-${teamHash}@m-league.jp`
-    const dtStart = `${startYear}${startMonth}${startDay}T190000`
-    const dtEnd = `${startYear}${startMonth}${startDay}T240000`
-
-    const summary = schedule.teams.map((team) => `[${team}]`).join('')
-    const description = `対戦チーム:\\n${schedule.teams.map((team) => `・${team}`).join('\\n')}`
-
-    icalLines.push('BEGIN:VEVENT')
-    icalLines.push(`UID:${uid}`)
-    icalLines.push(`DTSTART;TZID=Asia/Tokyo:${dtStart}`)
-    icalLines.push(`DTEND;TZID=Asia/Tokyo:${dtEnd}`)
-    icalLines.push(`SUMMARY:${summary}`)
-    icalLines.push(`DESCRIPTION:${description}`)
-    icalLines.push(`LOCATION:${schedule.url || 'ABEMA TV'}`)
-
-    // アラート設定（開始時刻に通知）
-    icalLines.push('BEGIN:VALARM')
-    icalLines.push('ACTION:DISPLAY')
-    icalLines.push('TRIGGER:PT0M')
-    icalLines.push(`DESCRIPTION:${summary}`)
-    icalLines.push('END:VALARM')
-
-    icalLines.push('END:VEVENT')
-  })
-
-  icalLines.push('END:VCALENDAR')
-
-  return icalLines.join('\r\n')
-}
-
-function saveToFile(filename: string, content: string): void {
-  const filepath = join(process.cwd(), filename)
-  writeFileSync(filepath, content, 'utf-8')
-  console.log(`Saved to ${filename}`)
-}
+import { generateICalendar } from './generators/ical-generator'
+import { MLeagueScraper } from './scrapers/m-league-scraper'
+import { saveToFile } from './utils/file-utils'
 
 async function main() {
   try {
     console.log('Starting M-League schedule fetcher...')
     console.log('Fetching all schedules from 2025/9 to 2026/5...\n')
 
-    const schedules = await scrapeAllMLeagueSchedules()
+    const scraper = new MLeagueScraper()
+    const schedules = await scraper.fetchAll()
 
     if (schedules.length === 0) {
       console.log('No schedule data found')
@@ -194,7 +17,7 @@ async function main() {
 
       const icalContent = generateICalendar(schedules)
 
-      // Also save to docs folder for GitHub Pages
+      // Save to docs folder for GitHub Pages
       saveToFile('docs/m-league-schedule.ics', icalContent)
 
       console.log('\nFiles generated successfully!')
@@ -209,4 +32,4 @@ async function main() {
 }
 
 // ESモジュールのエントリポイント
-main()
+void main()

--- a/src/generators/ical-generator.ts
+++ b/src/generators/ical-generator.ts
@@ -51,7 +51,10 @@ function generateEvent(schedule: Schedule): string[] {
   )
 
   const summary = schedule.teams.map((team) => `[${team}]`).join('')
-  const description = `${M_LEAGUE_CONFIG.calendar.description.prefix}\\n${schedule.teams.map((team) => `${M_LEAGUE_CONFIG.calendar.description.teamBullet}${team}`).join('\\n')}`
+  const teamList = schedule.teams
+    .map((team) => `${M_LEAGUE_CONFIG.calendar.description.teamBullet}${team}`)
+    .join('\\n')
+  const description = `${M_LEAGUE_CONFIG.calendar.description.prefix}\\n${teamList}`
   const location = schedule.url || M_LEAGUE_CONFIG.calendar.defaultLocation
 
   const eventLines = [

--- a/src/generators/ical-generator.ts
+++ b/src/generators/ical-generator.ts
@@ -1,0 +1,102 @@
+import { M_LEAGUE_CONFIG } from '../config'
+import type { Schedule } from '../types/schedule'
+import { formatDateTime, generateUid } from '../utils/calendar-utils'
+
+/**
+ * Generate iCalendar timezone section
+ * @returns Array of VTIMEZONE lines
+ */
+function generateTimezone(): string[] {
+  return [
+    'BEGIN:VTIMEZONE',
+    `TZID:${M_LEAGUE_CONFIG.calendar.timezone}`,
+    'BEGIN:STANDARD',
+    'DTSTART:19700101T000000',
+    'TZOFFSETFROM:+0900',
+    'TZOFFSETTO:+0900',
+    'END:STANDARD',
+    'END:VTIMEZONE',
+  ]
+}
+
+/**
+ * Generate iCalendar alarm section
+ * @param summary - Event summary for alarm description
+ * @returns Array of VALARM lines
+ */
+function generateAlarm(summary: string): string[] {
+  return [
+    'BEGIN:VALARM',
+    'ACTION:DISPLAY',
+    'TRIGGER:PT0M',
+    `DESCRIPTION:${summary}`,
+    'END:VALARM',
+  ]
+}
+
+/**
+ * Generate iCalendar event section
+ * @param schedule - Schedule object
+ * @returns Array of VEVENT lines
+ */
+function generateEvent(schedule: Schedule): string[] {
+  const uid = generateUid(schedule)
+  const dtStart = formatDateTime(
+    schedule.date,
+    M_LEAGUE_CONFIG.calendar.eventStartTime,
+  )
+  const dtEnd = formatDateTime(
+    schedule.date,
+    M_LEAGUE_CONFIG.calendar.eventEndTime,
+  )
+
+  const summary = schedule.teams.map((team) => `[${team}]`).join('')
+  const description = `対戦チーム:\\n${schedule.teams.map((team) => `・${team}`).join('\\n')}`
+  const location = schedule.url || M_LEAGUE_CONFIG.calendar.defaultLocation
+
+  const eventLines = [
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTART;TZID=${M_LEAGUE_CONFIG.calendar.timezone}:${dtStart}`,
+    `DTEND;TZID=${M_LEAGUE_CONFIG.calendar.timezone}:${dtEnd}`,
+    `SUMMARY:${summary}`,
+    `DESCRIPTION:${description}`,
+    `LOCATION:${location}`,
+  ]
+
+  eventLines.push(...generateAlarm(summary))
+  eventLines.push('END:VEVENT')
+
+  return eventLines
+}
+
+/**
+ * Generate complete iCalendar content
+ * @param schedules - Array of Schedule objects
+ * @returns iCalendar formatted string
+ */
+export function generateICalendar(schedules: Schedule[]): string {
+  const lines: string[] = []
+
+  // Calendar header
+  lines.push('BEGIN:VCALENDAR')
+  lines.push('VERSION:2.0')
+  lines.push('PRODID:-//M-League Schedule//JP')
+  lines.push('CALSCALE:GREGORIAN')
+  lines.push('METHOD:PUBLISH')
+  lines.push(`X-WR-CALNAME:${M_LEAGUE_CONFIG.calendar.name}`)
+  lines.push(`X-WR-TIMEZONE:${M_LEAGUE_CONFIG.calendar.timezone}`)
+
+  // Timezone
+  lines.push(...generateTimezone())
+
+  // Events
+  for (const schedule of schedules) {
+    lines.push(...generateEvent(schedule))
+  }
+
+  // Calendar footer
+  lines.push('END:VCALENDAR')
+
+  return lines.join('\r\n')
+}

--- a/src/generators/ical-generator.ts
+++ b/src/generators/ical-generator.ts
@@ -51,7 +51,7 @@ function generateEvent(schedule: Schedule): string[] {
   )
 
   const summary = schedule.teams.map((team) => `[${team}]`).join('')
-  const description = `対戦チーム:\\n${schedule.teams.map((team) => `・${team}`).join('\\n')}`
+  const description = `${M_LEAGUE_CONFIG.calendar.description.prefix}\\n${schedule.teams.map((team) => `${M_LEAGUE_CONFIG.calendar.description.teamBullet}${team}`).join('\\n')}`
   const location = schedule.url || M_LEAGUE_CONFIG.calendar.defaultLocation
 
   const eventLines = [

--- a/src/parsers/html-parser.ts
+++ b/src/parsers/html-parser.ts
@@ -70,26 +70,25 @@ function parseUrl(listContent: string): string | undefined {
  * @returns Array of Schedule objects
  */
 export function parseSchedules(html: string, year: number): Schedule[] {
-  const schedules: Schedule[] = []
   const listItems = parseScheduleListItems(html)
 
-  for (const listContent of listItems) {
-    const date = parseDate(listContent, year)
-    if (!date) continue
+  return listItems
+    .map((listContent) => {
+      const date = parseDate(listContent, year)
+      if (!date) return null
 
-    const teams = parseTeams(listContent)
-    if (teams.length === 0) continue
+      const teams = parseTeams(listContent)
+      if (teams.length === 0) return null
 
-    const url = parseUrl(listContent)
+      const url = parseUrl(listContent)
 
-    schedules.push({
-      date,
-      teams,
-      url,
+      return {
+        date,
+        teams,
+        url,
+      } as Schedule
     })
-  }
-
-  return schedules
+    .filter((schedule): schedule is Schedule => schedule !== null)
 }
 
 /**

--- a/src/parsers/html-parser.ts
+++ b/src/parsers/html-parser.ts
@@ -1,0 +1,102 @@
+import { M_LEAGUE_CONFIG } from '../config'
+import type { Schedule } from '../types/schedule'
+
+/**
+ * Parse schedule list items from HTML content
+ * @param html - HTML content from M-League website
+ * @returns Array of list item HTML strings
+ */
+function parseScheduleListItems(html: string): string[] {
+  const items: string[] = []
+  const listRegex = M_LEAGUE_CONFIG.regex.listItem
+  let match
+
+  while ((match = listRegex.exec(html)) !== null) {
+    items.push(match[0])
+  }
+
+  return items
+}
+
+/**
+ * Parse date from list item HTML
+ * @param listContent - HTML content of a single list item
+ * @param year - Year for the schedule
+ * @returns Date string in YYYY-MM-DD format, or null if not found
+ */
+function parseDate(listContent: string, year: number): string | null {
+  const dateMatch = listContent.match(M_LEAGUE_CONFIG.regex.date)
+  if (!dateMatch) return null
+
+  const monthStr = dateMatch[1].padStart(2, '0')
+  const dayStr = dateMatch[2].padStart(2, '0')
+  return `${year}-${monthStr}-${dayStr}`
+}
+
+/**
+ * Parse team names from list item HTML
+ * @param listContent - HTML content of a single list item
+ * @returns Array of team names
+ */
+function parseTeams(listContent: string): string[] {
+  const teams: string[] = []
+  const teamRegex = M_LEAGUE_CONFIG.regex.team
+  let match
+
+  while ((match = teamRegex.exec(listContent)) !== null) {
+    const teamName = match[1].trim()
+    if (teamName && !teamName.includes('M.League')) {
+      teams.push(teamName)
+    }
+  }
+
+  return teams
+}
+
+/**
+ * Parse URL from list item HTML
+ * @param listContent - HTML content of a single list item
+ * @returns URL string or undefined if not found
+ */
+function parseUrl(listContent: string): string | undefined {
+  const urlMatch = listContent.match(M_LEAGUE_CONFIG.regex.url)
+  return urlMatch ? urlMatch[1] : undefined
+}
+
+/**
+ * Parse M-League schedules from HTML content
+ * @param html - HTML content from M-League website
+ * @param year - Year for the schedules
+ * @returns Array of Schedule objects
+ */
+export function parseSchedules(html: string, year: number): Schedule[] {
+  const schedules: Schedule[] = []
+  const listItems = parseScheduleListItems(html)
+
+  for (const listContent of listItems) {
+    const date = parseDate(listContent, year)
+    if (!date) continue
+
+    const teams = parseTeams(listContent)
+    if (teams.length === 0) continue
+
+    const url = parseUrl(listContent)
+
+    schedules.push({
+      date,
+      teams,
+      url,
+    })
+  }
+
+  return schedules
+}
+
+/**
+ * Check if HTML contains schedule data
+ * @param html - HTML content to check
+ * @returns true if schedule data exists
+ */
+export function hasScheduleData(html: string): boolean {
+  return html.includes(M_LEAGUE_CONFIG.selectors.listClass)
+}

--- a/src/scrapers/m-league-scraper.ts
+++ b/src/scrapers/m-league-scraper.ts
@@ -1,0 +1,74 @@
+import { M_LEAGUE_CONFIG } from '../config'
+import { hasScheduleData, parseSchedules } from '../parsers/html-parser'
+import type { Period, Schedule } from '../types/schedule'
+
+export class MLeagueScraper {
+  /**
+   * Fetch schedule for a specific month
+   * @param year - Year to fetch
+   * @param month - Month to fetch
+   * @returns Array of Schedule objects
+   */
+  async fetchMonth(year: number, month: number): Promise<Schedule[]> {
+    const url = `${M_LEAGUE_CONFIG.baseUrl}?mly=${year}&mlm=${month}#schedule`
+
+    console.log(`Fetching schedule from: ${url}`)
+
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const html = await response.text()
+
+      // Check if schedule data exists
+      if (!hasScheduleData(html)) {
+        console.log(`  No schedule data available for ${year}/${month}`)
+        return []
+      }
+
+      return parseSchedules(html, year)
+    } catch (error) {
+      console.log(`  Error fetching schedule for ${year}/${month}:`, error)
+      return []
+    }
+  }
+
+  /**
+   * Fetch schedules for all configured periods
+   * @returns Array of all Schedule objects
+   */
+  async fetchAll(): Promise<Schedule[]> {
+    const allSchedules: Schedule[] = []
+
+    for (const period of M_LEAGUE_CONFIG.periods) {
+      const monthSchedules = await this.fetchMonth(period.year, period.month)
+      allSchedules.push(...monthSchedules)
+      console.log(
+        `  Found ${monthSchedules.length} matches for ${period.year}/${period.month}`,
+      )
+    }
+
+    return allSchedules
+  }
+
+  /**
+   * Fetch schedules for custom periods
+   * @param periods - Array of Period objects to fetch
+   * @returns Array of Schedule objects
+   */
+  async fetchPeriods(periods: Period[]): Promise<Schedule[]> {
+    const allSchedules: Schedule[] = []
+
+    for (const period of periods) {
+      const monthSchedules = await this.fetchMonth(period.year, period.month)
+      allSchedules.push(...monthSchedules)
+      console.log(
+        `  Found ${monthSchedules.length} matches for ${period.year}/${period.month}`,
+      )
+    }
+
+    return allSchedules
+  }
+}

--- a/src/scrapers/m-league-scraper.ts
+++ b/src/scrapers/m-league-scraper.ts
@@ -1,6 +1,6 @@
 import { M_LEAGUE_CONFIG } from '../config'
 import { hasScheduleData, parseSchedules } from '../parsers/html-parser'
-import type { Period, Schedule } from '../types/schedule'
+import type { Schedule } from '../types/schedule'
 
 export class MLeagueScraper {
   /**
@@ -43,25 +43,6 @@ export class MLeagueScraper {
     const allSchedules: Schedule[] = []
 
     for (const period of M_LEAGUE_CONFIG.periods) {
-      const monthSchedules = await this.fetchMonth(period.year, period.month)
-      allSchedules.push(...monthSchedules)
-      console.log(
-        `  Found ${monthSchedules.length} matches for ${period.year}/${period.month}`,
-      )
-    }
-
-    return allSchedules
-  }
-
-  /**
-   * Fetch schedules for custom periods
-   * @param periods - Array of Period objects to fetch
-   * @returns Array of Schedule objects
-   */
-  async fetchPeriods(periods: Period[]): Promise<Schedule[]> {
-    const allSchedules: Schedule[] = []
-
-    for (const period of periods) {
       const monthSchedules = await this.fetchMonth(period.year, period.month)
       allSchedules.push(...monthSchedules)
       console.log(

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,10 @@
+export interface Schedule {
+  date: string
+  teams: string[]
+  url?: string
+}
+
+export interface Period {
+  year: number
+  month: number
+}

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto'
+
+import type { Schedule } from '../types/schedule'
+
+/**
+ * Generate a deterministic UID for a schedule event
+ * @param schedule - Schedule object containing date and teams
+ * @returns UID string in the format: YYYY-MM-DD-hash@m-league.jp
+ */
+export function generateUid(schedule: Schedule): string {
+  const teamHash = createHash('sha256')
+    .update(schedule.date + [...schedule.teams].sort().join(','))
+    .digest('hex')
+    .substring(0, 12)
+
+  return `${schedule.date}-${teamHash}@m-league.jp`
+}
+
+/**
+ * Format a date string to iCalendar datetime format
+ * @param dateString - Date string in YYYY-MM-DD format
+ * @param timeString - Time string in HHMMSS format
+ * @returns Formatted datetime string: YYYYMMDDTHHMMSS
+ */
+export function formatDateTime(dateString: string, timeString: string): string {
+  const [year, month, day] = dateString.split('-')
+  return `${year}${month}${day}T${timeString}`
+}

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,0 +1,13 @@
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Save content to a file
+ * @param filename - Relative or absolute filename
+ * @param content - Content to write to the file
+ */
+export function saveToFile(filename: string, content: string): void {
+  const filepath = join(process.cwd(), filename)
+  writeFileSync(filepath, content, 'utf-8')
+  console.log(`Saved to ${filename}`)
+}


### PR DESCRIPTION
## Summary

fetcher.tsが複雑になってきたため、機能別にモジュールを分離してコードの保守性と可読性を向上させました。

### 主な変更点

- **fetcher.ts**: 216行 → 35行（83%削減）
- モジュール構造を導入して単一責任の原則を適用
- esbuildビルドシステムを導入（7.3kb、2msビルド）
- TypeScript型チェックスクリプトを追加

### モジュール構成

```
src/
├── types/schedule.ts          # 型定義
├── config.ts                  # 設定の集約
├── utils/
│   ├── calendar-utils.ts      # UID生成、日時フォーマット
│   └── file-utils.ts          # ファイル操作
├── parsers/
│   └── html-parser.ts         # HTML解析ロジック
├── generators/
│   └── ical-generator.ts      # iCalendar生成
├── scrapers/
│   └── m-league-scraper.ts    # スクレイパークラス
└── fetcher.ts                 # エントリポイント（35行）
```

### コミット履歴

9つのアトミックなコミットに分割：

1. 型定義とコンフィグを分離
2. ユーティリティ関数を分離
3. HTMLパーサーを分離
4. iCalendar生成器を分離
5. スクレイパーをクラス化
6. fetcher.tsを簡潔なエントリポイントに改善
7. esbuildビルドシステムを導入
8. CLAUDE.mdをリファクタリング内容に更新
9. 未使用のfetchPeriodsメソッドを削除

## Test plan

- [x] `npm run fetch` で正常にスケジュール取得（150件）
- [x] `npm run start` でビルド＆実行が成功
- [x] `npm run typecheck` で型チェックが通過
- [x] `npm run lint` でlintが通過
- [x] `npm run build` でesbuildビルドが成功（7.3kb、2ms）