### PR TITLE
ci: Dependabot PRでbun.lockを自動更新するワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-bun-lock.yml
+++ b/.github/workflows/dependabot-bun-lock.yml
@@ -1,7 +1,9 @@
 name: dependabot-bun-lock
 
 on:
-  pull_request:
+  push:
+    branches:
+      - "dependabot/**"
     paths:
       - "package.json"
 
@@ -15,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           token: ${{ secrets.PAT }}
 
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## 概要

Dependabotがpackage.jsonを更新した際に、bun.lockも自動的に更新するワークフローを追加する。

## 関連Issue/PR

なし

## 変更内容

- Dependabotブランチへのpush時にbun.lockを自動更新するワークフロー（`dependabot-bun-lock.yml`）を追加
- PATを使用して後続ワークフロー（CI）がトリガーされるように設定
- `push`トリガー + `paths: ["package.json"]`フィルタにより、Dependabotのforce push（リベース）後も確実に再実行され、かつワークフロー自身のpush（bun.lockのみ）では再トリガーされない設計

## レビュー観点

- `push`トリガーで`dependabot/**`ブランチに限定しているため、他のブランチには影響しない
- `paths: ["package.json"]`フィルタにより無限ループを防止している点
- `github.actor == 'dependabot[bot]'`の条件で、Dependabot以外のpushでは実行されない点

## 破壊的変更

なし

## テスト計画

- [ ] Dependabotがnpm依存関係のPRを作成した際にワークフローが実行されること
- [ ] bun.lockが自動更新・コミットされること
- [ ] 後続のCIワークフローがトリガーされること
- [ ] Dependabotのforce push後にワークフローが再実行されること