### PR TITLE
ci: Renovateの手動承認を無効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependencyDashboardApproval": false,
   "timezone": "Asia/Tokyo",
   "schedule": ["before 10am on Monday"],
   "reviewers": ["suzuryo"],


### PR DESCRIPTION
## 概要

RenovateのDependency Dashboard上での手動承認を無効化し、依存関係更新PRが自動的に作成されるようにする。

## 関連Issue/PR

- Related to #56

## 変更内容

- `renovate.json` に `"dependencyDashboardApproval": false` を追加

## レビュー観点

なし

## 破壊的変更

なし

## テスト計画

- [ ] マージ後にRenovateが承認なしでPRを自動作成すること