### PR TITLE
fix: Mトーナメントの試合終了時刻を開始から3時間30分後にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,9 @@ Mリーグ:
 Mトーナメント:
 
 - Event title format: `[Stage][Table][Player1][Player2][Player3][Player4]`
-- Time: 試合ごとに異なる
+- 開始時刻: 試合ごとに異なる
   (FINAL系は HTML から取得、予選系はデフォルト 19:00)
+- 終了時刻: 開始時刻 + `matchDurationMinutes` (デフォルト 210 分 = 3時間30分)
 - Calendar name: `Mトーナメント 2026 スケジュール`
   (年を跨がない大会なので年は単独。シーズン切替時に手動更新)
 - UID prefix: `@m-tournament.m-league.jp`

--- a/docs/m-tournament-schedule.ics
+++ b/docs/m-tournament-schedule.ics
@@ -16,7 +16,7 @@ END:VTIMEZONE
 BEGIN:VEVENT
 UID:2026-06-01-e49d118d6147@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260601T150000
-DTEND;TZID=Asia/Tokyo:20260601T235959
+DTEND;TZID=Asia/Tokyo:20260601T183000
 SUMMARY:[予選1st][A卓][松本吉弘][東城りお][河野高志][清水香織]
 DESCRIPTION:対戦選手:\n・松本吉弘\n・東城りお\n・河野高志\n・清水香織
 LOCATION:https://abema.tv/now-on-air/mahjong
@@ -29,7 +29,7 @@ END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-01-2f78e7da30f4@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260601T190000
-DTEND;TZID=Asia/Tokyo:20260601T235959
+DTEND;TZID=Asia/Tokyo:20260601T223000
 SUMMARY:[予選1st][B卓][佐々木寿人][小池諒][中田花奈][宮崎和樹]
 DESCRIPTION:対戦選手:\n・佐々木寿人\n・小池諒\n・中田花奈\n・宮崎和樹
 LOCATION:https://abema.tv/now-on-air/mahjong

--- a/src/__tests__/calendar-utils.test.ts
+++ b/src/__tests__/calendar-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { Schedule } from '../types/schedule'
 import type { TournamentMatch } from '../types/tournament-match'
 import {
+  addMinutesToTime,
   formatDateTime,
   generateTournamentUid,
   generateUid,
@@ -192,6 +193,28 @@ describe('calendar-utils', () => {
 
       expect(result1).toBe('20250902T000000')
       expect(result2).toBe('20250902T123456')
+    })
+  })
+
+  describe('addMinutesToTime', () => {
+    it('19:00:00に210分(3時間30分)を加算すると22:30:00', () => {
+      expect(addMinutesToTime('190000', 210)).toBe('223000')
+    })
+
+    it('15:00:00に210分を加算すると18:30:00', () => {
+      expect(addMinutesToTime('150000', 210)).toBe('183000')
+    })
+
+    it('0分の加算は元の時刻を返す', () => {
+      expect(addMinutesToTime('190000', 0)).toBe('190000')
+    })
+
+    it('秒の部分は保持される', () => {
+      expect(addMinutesToTime('190030', 30)).toBe('193030')
+    })
+
+    it('24時間を超える場合は24時間でラップする', () => {
+      expect(addMinutesToTime('230000', 120)).toBe('010000')
     })
   })
 })

--- a/src/__tests__/tournament-extra-parser.test.ts
+++ b/src/__tests__/tournament-extra-parser.test.ts
@@ -34,7 +34,7 @@ describe('tournament-extra-parser', () => {
       expect(matches[0]).toEqual({
         date: '2026-08-15',
         startTime: '190000',
-        endTime: '235959',
+        endTime: '223000',
         stage: '予選1st',
         table: 'C卓',
         players: ['選手A', '選手B', '選手C', '選手D'],
@@ -48,11 +48,11 @@ describe('tournament-extra-parser', () => {
       expect(matches[1].startTime).toBe('190000')
     })
 
-    it('endTimeは常に235959', () => {
+    it('endTimeはstartTimeから3時間30分後', () => {
       const matches = parseExtraData(SAMPLE_FILE)
 
       for (const match of matches) {
-        expect(match.endTime).toBe('235959')
+        expect(match.endTime).toBe('223000')
       }
     })
 

--- a/src/__tests__/tournament-html-parser.test.ts
+++ b/src/__tests__/tournament-html-parser.test.ts
@@ -96,11 +96,15 @@ describe('tournament-html-parser', () => {
       }
     })
 
-    it('endTimeは全試合で235959', () => {
+    it('endTimeはstartTimeから3時間30分後', () => {
       const matches = parseTournamentMatches(FIXTURE_HTML, 2025)
 
       for (const match of matches) {
-        expect(match.endTime).toBe('235959')
+        if (match.startTime === '190000') {
+          expect(match.endTime).toBe('223000')
+        } else if (match.startTime === '150000') {
+          expect(match.endTime).toBe('183000')
+        }
       }
     })
 

--- a/src/config-tournament.ts
+++ b/src/config-tournament.ts
@@ -11,7 +11,8 @@ export const M_TOURNAMENT_CONFIG = {
     name: 'Mトーナメント 2026 スケジュール',
     timezone: 'Asia/Tokyo',
     defaultStartTime: '190000',
-    defaultEndTime: '235959',
+    // 試合の長さ (分)。開始時刻 + これが終了時刻になる。
+    matchDurationMinutes: 210,
     // Fallback URL used as the event location when schedule.url is undefined.
     defaultLocation: 'https://abema.tv/now-on-air/mahjong',
     description: {

--- a/src/parsers/tournament-extra-parser.ts
+++ b/src/parsers/tournament-extra-parser.ts
@@ -4,6 +4,7 @@ import { parse } from 'yaml'
 
 import { M_TOURNAMENT_CONFIG } from '../config-tournament'
 import type { TournamentMatch } from '../types/tournament-match'
+import { addMinutesToTime } from '../utils/calendar-utils'
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 const TIME_PATTERN = /^\d{6}$/
@@ -54,7 +55,10 @@ function validateEntry(entry: RawEntry): TournamentMatch | null {
   return {
     date: entry.date,
     startTime,
-    endTime: M_TOURNAMENT_CONFIG.calendar.defaultEndTime,
+    endTime: addMinutesToTime(
+      startTime,
+      M_TOURNAMENT_CONFIG.calendar.matchDurationMinutes,
+    ),
     stage,
     table,
     players,

--- a/src/parsers/tournament-html-parser.ts
+++ b/src/parsers/tournament-html-parser.ts
@@ -1,5 +1,6 @@
 import { M_TOURNAMENT_CONFIG } from '../config-tournament'
 import type { TournamentMatch } from '../types/tournament-match'
+import { addMinutesToTime } from '../utils/calendar-utils'
 
 type SectionConfig =
   (typeof M_TOURNAMENT_CONFIG.sections)[keyof typeof M_TOURNAMENT_CONFIG.sections]
@@ -132,7 +133,10 @@ function parseSection(
       return {
         date: dt.date,
         startTime: dt.startTime,
-        endTime: M_TOURNAMENT_CONFIG.calendar.defaultEndTime,
+        endTime: addMinutesToTime(
+          dt.startTime,
+          M_TOURNAMENT_CONFIG.calendar.matchDurationMinutes,
+        ),
         stage: st.stage,
         table: st.table,
         players,

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -34,6 +34,22 @@ export function formatDateTime(dateString: string, timeString: string): string {
 }
 
 /**
+ * Add minutes to a HHMMSS time string. Wraps within 24 hours.
+ * @param timeString - HHMMSS format time
+ * @param minutes - Minutes to add (non-negative)
+ * @returns HHMMSS format
+ */
+export function addMinutesToTime(timeString: string, minutes: number): string {
+  const h = Number.parseInt(timeString.substring(0, 2), 10)
+  const m = Number.parseInt(timeString.substring(2, 4), 10)
+  const s = timeString.substring(4, 6)
+  const total = h * 60 + m + minutes
+  const newH = Math.floor(total / 60) % 24
+  const newM = total % 60
+  return `${String(newH).padStart(2, '0')}${String(newM).padStart(2, '0')}${s}`
+}
+
+/**
  * Generate a deterministic UID for a tournament match event
  * @param match - TournamentMatch object containing date, stage, table, and players
  * @returns UID string in the format: YYYY-MM-DD-hash@m-tournament.m-league.jp


### PR DESCRIPTION
## 概要

これまで全試合で `endTime` が `23:59:59` 固定だったのを、開始時刻 + 3時間30分(210分) に変更します。
半荘の所要時間として現実的な値です。

## 変更内容

- `M_TOURNAMENT_CONFIG.calendar.defaultEndTime` を削除
- `M_TOURNAMENT_CONFIG.calendar.matchDurationMinutes: 210` を追加
- `addMinutesToTime(timeString, minutes)` を `calendar-utils.ts` に追加 (TDD)
- 公式パーサー / 補助データパーサーの両方で `addMinutesToTime` を使って endTime を計算
- 関連テストの期待値を新仕様に合わせて更新
- `docs/m-tournament-schedule.ics` を再生成

## 効果

| 開始時刻 | 修正前 | 修正後 |
| --- | --- | --- |
| 19:00 | 23:59:59 | **22:30:00** |
| 15:00 | 23:59:59 | **18:30:00** |

## 検証

- 全テスト 115 passed
- 全モジュール Lines カバレッジ 100%
- `bun run fetch` で実環境動作確認: 6/1 A卓(15:00→18:30) / B卓(19:00→22:30) で正しく出力

## Test plan

- [ ] CI green
- [ ] main マージ後、カレンダーアプリで試合の終了時刻が想定通りになっていることを確認