### PR TITLE
fix: Mトーナメントのイベントタイトル形式を読みやすく変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,8 @@ Mリーグ:
 
 Mトーナメント:
 
-- Event title format: `[Stage][Table][Player1][Player2][Player3][Player4]`
+- Event title format: `[Stage Table] Player1・Player2・Player3・Player4`
+  (stage/tableのどちらかが欠ける場合は[]内が片方のみ、両方欠ける場合は[]を省略)
 - 開始時刻: 試合ごとに異なる
   (FINAL系は HTML から取得、予選系はデフォルト 19:00)
 - 終了時刻: 開始時刻 + `matchDurationMinutes` (デフォルト 210 分 = 3時間30分)

--- a/docs/m-tournament-schedule.ics
+++ b/docs/m-tournament-schedule.ics
@@ -17,104 +17,104 @@ BEGIN:VEVENT
 UID:2026-06-01-e49d118d6147@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260601T150000
 DTEND;TZID=Asia/Tokyo:20260601T183000
-SUMMARY:[予選1st][A卓][松本吉弘][東城りお][河野高志][清水香織]
+SUMMARY:[予選1st A卓] 松本吉弘・東城りお・河野高志・清水香織
 DESCRIPTION:対戦選手:\n・松本吉弘\n・東城りお\n・河野高志\n・清水香織
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][A卓][松本吉弘][東城りお][河野高志][清水香織]
+DESCRIPTION:[予選1st A卓] 松本吉弘・東城りお・河野高志・清水香織
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-01-2f78e7da30f4@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260601T190000
 DTEND;TZID=Asia/Tokyo:20260601T223000
-SUMMARY:[予選1st][B卓][佐々木寿人][小池諒][中田花奈][宮崎和樹]
+SUMMARY:[予選1st B卓] 佐々木寿人・小池諒・中田花奈・宮崎和樹
 DESCRIPTION:対戦選手:\n・佐々木寿人\n・小池諒\n・中田花奈\n・宮崎和樹
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][B卓][佐々木寿人][小池諒][中田花奈][宮崎和樹]
+DESCRIPTION:[予選1st B卓] 佐々木寿人・小池諒・中田花奈・宮崎和樹
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-05-e0c90061d13f@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260605T150000
 DTEND;TZID=Asia/Tokyo:20260605T183000
-SUMMARY:[予選1st][C卓][小林剛][小川光][塩澤彰大][奥村知美]
+SUMMARY:[予選1st C卓] 小林剛・小川光・塩澤彰大・奥村知美
 DESCRIPTION:対戦選手:\n・小林剛\n・小川光\n・塩澤彰大\n・奥村知美
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][C卓][小林剛][小川光][塩澤彰大][奥村知美]
+DESCRIPTION:[予選1st C卓] 小林剛・小川光・塩澤彰大・奥村知美
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-05-917db8b33b3d@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260605T190000
 DTEND;TZID=Asia/Tokyo:20260605T223000
-SUMMARY:[予選1st][D卓][石原真人][HIRO柴田][徐曄][魚谷侑未]
+SUMMARY:[予選1st D卓] 石原真人・HIRO柴田・徐曄・魚谷侑未
 DESCRIPTION:対戦選手:\n・石原真人\n・HIRO柴田\n・徐曄\n・魚谷侑未
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][D卓][石原真人][HIRO柴田][徐曄][魚谷侑未]
+DESCRIPTION:[予選1st D卓] 石原真人・HIRO柴田・徐曄・魚谷侑未
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-08-5a5f5e334aae@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260608T150000
 DTEND;TZID=Asia/Tokyo:20260608T183000
-SUMMARY:[予選1st][E卓][園田賢][本田朋広][日向藍子][渡辺史哉]
+SUMMARY:[予選1st E卓] 園田賢・本田朋広・日向藍子・渡辺史哉
 DESCRIPTION:対戦選手:\n・園田賢\n・本田朋広\n・日向藍子\n・渡辺史哉
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][E卓][園田賢][本田朋広][日向藍子][渡辺史哉]
+DESCRIPTION:[予選1st E卓] 園田賢・本田朋広・日向藍子・渡辺史哉
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-08-76d9c9ef4b3f@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260608T190000
 DTEND;TZID=Asia/Tokyo:20260608T223000
-SUMMARY:[予選1st][F卓][仲林圭][黒沢咲][近藤誠一][朝比奈ゆり]
+SUMMARY:[予選1st F卓] 仲林圭・黒沢咲・近藤誠一・朝比奈ゆり
 DESCRIPTION:対戦選手:\n・仲林圭\n・黒沢咲\n・近藤誠一\n・朝比奈ゆり
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][F卓][仲林圭][黒沢咲][近藤誠一][朝比奈ゆり]
+DESCRIPTION:[予選1st F卓] 仲林圭・黒沢咲・近藤誠一・朝比奈ゆり
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-12-262f6cb7d016@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260612T150000
 DTEND;TZID=Asia/Tokyo:20260612T183000
-SUMMARY:[予選1st][G卓][逢川恵夢][藤崎智][浅井堂岐][羽月まりえ]
+SUMMARY:[予選1st G卓] 逢川恵夢・藤崎智・浅井堂岐・羽月まりえ
 DESCRIPTION:対戦選手:\n・逢川恵夢\n・藤崎智\n・浅井堂岐\n・羽月まりえ
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][G卓][逢川恵夢][藤崎智][浅井堂岐][羽月まりえ]
+DESCRIPTION:[予選1st G卓] 逢川恵夢・藤崎智・浅井堂岐・羽月まりえ
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:2026-06-12-9edd01828eb2@m-tournament.m-league.jp
 DTSTART;TZID=Asia/Tokyo:20260612T190000
 DTEND;TZID=Asia/Tokyo:20260612T223000
-SUMMARY:[予選1st][H卓][渋川難波][鈴木たろう][村上淳][角葉子]
+SUMMARY:[予選1st H卓] 渋川難波・鈴木たろう・村上淳・角葉子
 DESCRIPTION:対戦選手:\n・渋川難波\n・鈴木たろう\n・村上淳\n・角葉子
 LOCATION:https://abema.tv/now-on-air/mahjong
 BEGIN:VALARM
 ACTION:DISPLAY
 TRIGGER:PT0M
-DESCRIPTION:[予選1st][H卓][渋川難波][鈴木たろう][村上淳][角葉子]
+DESCRIPTION:[予選1st H卓] 渋川難波・鈴木たろう・村上淳・角葉子
 END:VALARM
 END:VEVENT
 END:VCALENDAR

--- a/src/__tests__/tournament-ical-generator.test.ts
+++ b/src/__tests__/tournament-ical-generator.test.ts
@@ -29,7 +29,7 @@ describe('tournament-ical-generator', () => {
       expect(ical).toContain('TZID:Asia/Tokyo')
       expect(ical).toContain('BEGIN:VEVENT')
       expect(ical).toContain(
-        'SUMMARY:[FINAL STAGE][A卓][小林剛][伊達朱里紗][佐々木寿人][堀慎吾]',
+        'SUMMARY:[FINAL STAGE A卓] 小林剛・伊達朱里紗・佐々木寿人・堀慎吾',
       )
       expect(ical).toContain('DTSTART;TZID=Asia/Tokyo:20260728T190000')
       expect(ical).toContain('DTEND;TZID=Asia/Tokyo:20260728T235959')
@@ -87,8 +87,8 @@ describe('tournament-ical-generator', () => {
       const eventCount = (ical.match(/BEGIN:VEVENT/g) || []).length
       expect(eventCount).toBe(2)
 
-      expect(ical).toContain('SUMMARY:[予選1st][A卓][A][B][C][D]')
-      expect(ical).toContain('SUMMARY:[予選1st][B卓][E][F][G][H]')
+      expect(ical).toContain('SUMMARY:[予選1st A卓] A・B・C・D')
+      expect(ical).toContain('SUMMARY:[予選1st B卓] E・F・G・H')
       expect(ical).toContain('DTSTART;TZID=Asia/Tokyo:20260728T190000')
       expect(ical).toContain('DTSTART;TZID=Asia/Tokyo:20260729T150000')
     })
@@ -151,9 +151,8 @@ describe('tournament-ical-generator', () => {
 
       const ical = generateTournamentICalendar(matches)
 
-      // 卓部分は空のブラケットや欠落でも、stage と players は出る
-      expect(ical).toContain('[FINAL]')
-      expect(ical).toContain('[A]')
+      // 卓が空でも、stage と players が連結された summary が出る
+      expect(ical).toContain('SUMMARY:[FINAL] A・B・C・D')
     })
   })
 })

--- a/src/generators/tournament-ical-generator.ts
+++ b/src/generators/tournament-ical-generator.ts
@@ -44,17 +44,17 @@ function generateEvent(match: TournamentMatch): string[] {
   const dtStart = formatDateTime(match.date, match.startTime)
   const dtEnd = formatDateTime(match.date, match.endTime)
 
-  const summaryParts: string[] = []
+  const headerParts: string[] = []
   if (match.stage) {
-    summaryParts.push(`[${match.stage}]`)
+    headerParts.push(match.stage)
   }
   if (match.table) {
-    summaryParts.push(`[${match.table}]`)
+    headerParts.push(match.table)
   }
-  for (const player of match.players) {
-    summaryParts.push(`[${player}]`)
-  }
-  const summary = summaryParts.join('')
+  const header = headerParts.length > 0 ? `[${headerParts.join(' ')}]` : ''
+  const playersStr = match.players.join('・')
+  const summary =
+    header && playersStr ? `${header} ${playersStr}` : `${header}${playersStr}`
 
   const playerList = match.players
     .map(


### PR DESCRIPTION
## 概要

Mトーナメントの iCal イベントタイトル(SUMMARY)を、選手名が連続する `[]` で読みづらかった形式から、ステージと卓を1つの `[]` にまとめ選手名を中黒(・)で連結する形式に変更する。

## 関連Issue/PR

なし

## 変更内容

タイトル形式の変更:

- 旧: `[予選1st][A卓][松本吉弘][東城りお][河野高志][清水香織]`
- 新: `[予選1st A卓] 松本吉弘・東城りお・河野高志・清水香織`

実装:

- `src/generators/tournament-ical-generator.ts` の summary 組み立てロジックを修正
- stage と table をスペース区切りで1つの `[]` に格納
- 選手名は中黒(`・`)で連結し、`[]` の後に半角スペース1つで続ける
- stage/table のどちらかが欠ける場合は `[]` 内が片方のみ、両方欠ける場合は `[]` 自体を省略

テスト・ドキュメント:

- `src/__tests__/tournament-ical-generator.test.ts` の assertion を新形式に更新
- `CLAUDE.md` の Event title format 記載を更新
- `docs/m-tournament-schedule.ics` を再生成

## レビュー観点

- Mリーグ側 (`[Team1][Team2][Team3][Team4]`) は短いチーム名なので変更していない。Mトーナメントは選手フルネームのため別形式とする判断で良いか
- 選手名の区切り文字に中黒(`・`)を採用 (他候補: スラッシュ `/` / 読点 `、`)
- stage/table が両方欠けるケース (現状は無いが、防御的に `[]` 省略で扱う) のテストは追加していない

## 破壊的変更

カレンダー購読者側で表示が変わるが、UID は変わらないので既存イベントが重複したり消えたりはしない。

## テスト計画

- [x] `bun run test` (115 tests passed)
- [x] `bun run typecheck` でエラーなし
- [x] `bun run lint` でエラーなし
- [x] `bun run fetch` で生成された `docs/m-tournament-schedule.ics` の SUMMARY が新形式になっていることを確認