### PR TITLE
feat: Mトーナメント対戦カード(第5〜6弾)を追加

### DIFF
--- a/data/m-tournament-extra.yaml
+++ b/data/m-tournament-extra.yaml
@@ -113,3 +113,51 @@ matches:
       - 村上淳
       - 角葉子
     source: "https://x.com/m_league_/status/2059156579329642544"
+
+  # 2026/6/15 Mトーナメント2026 対戦カード発表 第5弾
+  - date: "2026-06-15"
+    stage: "予選1st"
+    table: "I卓"
+    startTime: "150000"
+    players:
+      - 醍醐大
+      - 鈴木大介
+      - 菅原千瑛
+      - 紺野真太郎
+    source: "https://x.com/m_league_/status/2059878586161500541"
+
+  # J卓は「進行次第で時間変更あり」と但し書きあり (X投稿原文ママ)
+  - date: "2026-06-15"
+    stage: "予選1st"
+    table: "J卓"
+    startTime: "190000"
+    players:
+      - 伊達朱里紗
+      - 三浦智博
+      - 今村大樹
+      - 牧野伸彦
+    source: "https://x.com/m_league_/status/2059878586161500541"
+
+  # 2026/6/19 Mトーナメント2026 対戦カード発表 第6弾
+  - date: "2026-06-19"
+    stage: "予選1st"
+    table: "K卓"
+    startTime: "150000"
+    players:
+      - 茅森早香
+      - 阿久津翔太
+      - 安藤弘樹
+      - 前田直哉
+    source: "https://x.com/m_league_/status/2059878837576511913"
+
+  # L卓は「進行次第で時間変更あり」と但し書きあり (X投稿原文ママ)
+  - date: "2026-06-19"
+    stage: "予選1st"
+    table: "L卓"
+    startTime: "190000"
+    players:
+      - 瑞原明奈
+      - 吉田幸雄
+      - 浜野太陽
+      - 西村雄一郎
+    source: "https://x.com/m_league_/status/2059878837576511913"

--- a/docs/m-tournament-schedule.ics
+++ b/docs/m-tournament-schedule.ics
@@ -117,4 +117,56 @@ TRIGGER:PT0M
 DESCRIPTION:[予選1st H卓] 渋川難波・鈴木たろう・村上淳・角葉子
 END:VALARM
 END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-15-2dee3749ace8@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260615T150000
+DTEND;TZID=Asia/Tokyo:20260615T183000
+SUMMARY:[予選1st I卓] 醍醐大・鈴木大介・菅原千瑛・紺野真太郎
+DESCRIPTION:対戦選手:\n・醍醐大\n・鈴木大介\n・菅原千瑛\n・紺野真太郎
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st I卓] 醍醐大・鈴木大介・菅原千瑛・紺野真太郎
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-15-a61921c46e2a@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260615T190000
+DTEND;TZID=Asia/Tokyo:20260615T223000
+SUMMARY:[予選1st J卓] 伊達朱里紗・三浦智博・今村大樹・牧野伸彦
+DESCRIPTION:対戦選手:\n・伊達朱里紗\n・三浦智博\n・今村大樹\n・牧野伸彦
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st J卓] 伊達朱里紗・三浦智博・今村大樹・牧野伸彦
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-19-b8315fab5321@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260619T150000
+DTEND;TZID=Asia/Tokyo:20260619T183000
+SUMMARY:[予選1st K卓] 茅森早香・阿久津翔太・安藤弘樹・前田直哉
+DESCRIPTION:対戦選手:\n・茅森早香\n・阿久津翔太\n・安藤弘樹\n・前田直哉
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st K卓] 茅森早香・阿久津翔太・安藤弘樹・前田直哉
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-19-6a677358c3c4@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260619T190000
+DTEND;TZID=Asia/Tokyo:20260619T223000
+SUMMARY:[予選1st L卓] 瑞原明奈・吉田幸雄・浜野太陽・西村雄一郎
+DESCRIPTION:対戦選手:\n・瑞原明奈\n・吉田幸雄\n・浜野太陽\n・西村雄一郎
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st L卓] 瑞原明奈・吉田幸雄・浜野太陽・西村雄一郎
+END:VALARM
+END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
## 概要

X (Twitter) で先行発表された Mトーナメント2026 対戦カード 第5弾・第6弾を補助データ (`data/m-tournament-extra.yaml`) に追加する。

## 関連Issue/PR

なし

## 変更内容

- 第5弾 (2026/6/15) を追加
  - I卓 (15時～): 醍醐大・鈴木大介・菅原千瑛・紺野真太郎
  - J卓 (19時～): 伊達朱里紗・三浦智博・今村大樹・牧野伸彦
- 第6弾 (2026/6/19) を追加
  - K卓 (15時～): 茅森早香・阿久津翔太・安藤弘樹・前田直哉
  - L卓 (19時～): 瑞原明奈・吉田幸雄・浜野太陽・西村雄一郎
- 生成物 `docs/m-tournament-schedule.ics` を再生成 (Mトーナメント 8試合 → 12試合)

## レビュー観点

- ステージ名は投稿に明記がないため、第1〜4弾と同様に「予選1st」と推測している (公式サイトに同じ試合が出れば date+stage+table キーで自動上書きされる)
- J卓・L卓は X投稿に「進行次第で時間変更あり」の但し書きがあり、YAMLコメントに原文ママで記載
- 選手名の表記揺れ (漢字・かな) が原文と一致しているか

## 破壊的変更

なし

## テスト計画

- [x] `bun run test` が全件パス (115 tests)
- [x] `bun run fetch` が成功し ICS が再生成される
- [x] 生成 ICS に第5弾・第6弾の VEVENT が含まれることを確認