### PR TITLE
chore: 依存とツールのバージョンを固定・整合

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "vitest": "4.1.7"
   },
   "dependencies": {
-    "yaml": "^2.9.0"
+    "yaml": "2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       yaml:
-        specifier: ^2.9.0
+        specifier: 2.9.0
         version: 2.9.0
     devDependencies:
       '@biomejs/biome':


### PR DESCRIPTION
## 概要

`yaml` の依存バージョン固定と、Biome 設定の `$schema` を CLI バージョンに合わせることで、バージョンの整合性を取る。

## 関連Issue/PR

なし

## 変更内容

- `biome.json` の `$schema` を `2.4.9` → `2.4.15` に更新し、Biome CLI (`@biomejs/biome@2.4.15`) のバージョンと一致させた（起動時のスキーマバージョン不一致の警告を解消）
- `package.json` の `yaml` を `^2.9.0` → `2.9.0` に固定（`devDependencies` と同様にキャレットなしの完全固定に統一）
- `pnpm-lock.yaml` の specifier を `2.9.0` に更新

## レビュー観点

- `yaml` は `src/parsers/tournament-extra-parser.ts` で補助データ (`data/m-tournament-extra.yaml`) のパースに使用されており、機能上必要な依存。バージョン固定により予期しないマイナー/パッチ更新を防ぐ意図
- 既存の `devDependencies` がすべてキャレットなしで固定されているため、それに合わせて `dependencies` も固定する方針とした

## 破壊的変更

なし

## テスト計画

- [x] `pnpm run lint` がエラーなく通ること
- [x] `pnpm run typecheck` がエラーなく通ること
- [x] `pnpm run test` が全件パスすること（115 tests）