### PR TITLE
feat: Mトーナメント対戦カード(第7〜8弾)を追加

### DIFF
--- a/data/m-tournament-extra.yaml
+++ b/data/m-tournament-extra.yaml
@@ -161,3 +161,51 @@ matches:
       - 浜野太陽
       - 西村雄一郎
     source: "https://x.com/m_league_/status/2059878837576511913"
+
+  # 2026/6/22 Mトーナメント2026 対戦カード発表 第7弾
+  - date: "2026-06-22"
+    stage: "予選1st"
+    table: "M卓"
+    startTime: "150000"
+    players:
+      - 渡辺太
+      - 鈴木優
+      - 高宮まり
+      - 石川正明
+    source: "https://x.com/m_league_/status/2060241728636940589"
+
+  # N卓は「進行次第で時間変更あり」と但し書きあり (X投稿原文ママ)
+  - date: "2026-06-22"
+    stage: "予選1st"
+    table: "N卓"
+    startTime: "190000"
+    players:
+      - 多井隆晴
+      - 瀬戸熊直樹
+      - 鈴木聡一郎
+      - 桑田憲汰
+    source: "https://x.com/m_league_/status/2060241728636940589"
+
+  # 2026/6/26 Mトーナメント2026 対戦カード発表 第8弾
+  - date: "2026-06-26"
+    stage: "予選1st"
+    table: "O卓"
+    startTime: "150000"
+    players:
+      - 浅見真紀
+      - 竹内元太
+      - 忍田幸夫
+      - 和久津晶
+    source: "https://x.com/m_league_/status/2060241980232270333"
+
+  # P卓は「進行次第で時間変更あり」と但し書きあり (X投稿原文ママ)
+  - date: "2026-06-26"
+    stage: "予選1st"
+    table: "P卓"
+    startTime: "190000"
+    players:
+      - 堀慎吾
+      - 石井一馬
+      - 萩原聖人
+      - 高津柚那
+    source: "https://x.com/m_league_/status/2060241980232270333"

--- a/public/m-tournament-schedule.ics
+++ b/public/m-tournament-schedule.ics
@@ -169,4 +169,56 @@ TRIGGER:PT0M
 DESCRIPTION:[予選1st L卓] 瑞原明奈・吉田幸雄・浜野太陽・西村雄一郎
 END:VALARM
 END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-22-0d9a58469c9d@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260622T150000
+DTEND;TZID=Asia/Tokyo:20260622T183000
+SUMMARY:[予選1st M卓] 渡辺太・鈴木優・高宮まり・石川正明
+DESCRIPTION:対戦選手:\n・渡辺太\n・鈴木優\n・高宮まり\n・石川正明
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st M卓] 渡辺太・鈴木優・高宮まり・石川正明
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-22-2aeb43c2535f@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260622T190000
+DTEND;TZID=Asia/Tokyo:20260622T223000
+SUMMARY:[予選1st N卓] 多井隆晴・瀬戸熊直樹・鈴木聡一郎・桑田憲汰
+DESCRIPTION:対戦選手:\n・多井隆晴\n・瀬戸熊直樹\n・鈴木聡一郎\n・桑田憲汰
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st N卓] 多井隆晴・瀬戸熊直樹・鈴木聡一郎・桑田憲汰
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-26-1e0fb6fe8330@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260626T150000
+DTEND;TZID=Asia/Tokyo:20260626T183000
+SUMMARY:[予選1st O卓] 浅見真紀・竹内元太・忍田幸夫・和久津晶
+DESCRIPTION:対戦選手:\n・浅見真紀\n・竹内元太\n・忍田幸夫\n・和久津晶
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st O卓] 浅見真紀・竹内元太・忍田幸夫・和久津晶
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:2026-06-26-83b44254a4ad@m-tournament.m-league.jp
+DTSTART;TZID=Asia/Tokyo:20260626T190000
+DTEND;TZID=Asia/Tokyo:20260626T223000
+SUMMARY:[予選1st P卓] 堀慎吾・石井一馬・萩原聖人・高津柚那
+DESCRIPTION:対戦選手:\n・堀慎吾\n・石井一馬\n・萩原聖人\n・高津柚那
+LOCATION:https://abema.tv/now-on-air/mahjong
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT0M
+DESCRIPTION:[予選1st P卓] 堀慎吾・石井一馬・萩原聖人・高津柚那
+END:VALARM
+END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
## 概要

X (Twitter) で先行発表された Mトーナメント2026 の対戦カード第7弾・第8弾を補助データ (`data/m-tournament-extra.yaml`) に追記する。

## 関連Issue/PR

なし

## 変更内容

- 第7弾 (6/22(月)) を追加
  - M卓 (15:00〜): 渡辺太・鈴木優・高宮まり・石川正明
  - N卓 (19:00〜 ※進行次第で時間変更あり): 多井隆晴・瀬戸熊直樹・鈴木聡一郎・桑田憲汰
  - source: <https://x.com/m_league_/status/2060241728636940589>
- 第8弾 (6/26(金)) を追加
  - O卓 (15:00〜): 浅見真紀・竹内元太・忍田幸夫・和久津晶
  - P卓 (19:00〜 ※進行次第で時間変更あり): 堀慎吾・石井一馬・萩原聖人・高津柚那
  - source: <https://x.com/m_league_/status/2060241980232270333>
- `pnpm run fetch` で `public/m-tournament-schedule.ics` を再生成 (M-Tournament: 12 → 16 試合)

## レビュー観点

- 卓名はアルファベット順の既存パターン (A〜L卓) に続けて M/N/O/P 卓を割り当て、X投稿の卓名表記と一致している
- stage は X投稿に明記がないため既存エントリと同様に `予選1st` と推測。公式サイトに同じ試合 (date+stage+table キー) が掲載されれば自動的に公式情報で上書きされる
- 選手名は X投稿のハッシュタグ原文ママで転記

## 破壊的変更

なし

## テスト計画

- [x] `pnpm run fetch` が正常終了し ics が再生成される
- [x] 生成された ics に 6/22 (M/N卓)・6/26 (O/P卓) のイベントが含まれる
- [x] M-Tournament の試合数が 16 件 (第1〜8弾 × 2卓) になる