### PR TITLE
chore: Renovate を config:best-practices 化し依存更新ポリシーを標準化

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,9 @@
-# サプライチェーン攻撃対策: 公開から 4320 分 (= 3 日) 未満のバージョンは
-# 依存解決時に除外する。悪意あるパッケージの多くは公開後 数時間〜数日で
-# 検出・削除されるため、その猶予期間を設けることで取り込みを防ぐ。
-# (pnpm 11 では minimumReleaseAge を明示すると strict モードが有効になり強制される。
-#  Renovate 側の minimumReleaseAge をこの値より長く設定し、PR 作成時点で
-#  pnpm install が確実に解決できるようにしている)
-minimumReleaseAge: 4320
+# Supply-chain security (pnpm v11+, 単位: 分)
+# 2880 = 48h。pnpm v11 デフォルト (1440/24h) より厳しくした独自値で、
+# 手動 pnpm add や lockFileMaintenance / pin 経由で入る間接依存にも 48h の猶予を与える。
+# Renovate 側でも config:best-practices の security:minimumReleaseAgeNpm により
+# npm パッケージは公開 3 日待ちとなり、pnpm floor (2日) <= Renovate gate (3日) を維持する。
+minimumReleaseAge: 2880
 
 # 依存パッケージの install 時ビルドスクリプト実行はデフォルトで全てブロックする
 # (サプライチェーン攻撃対策)。tsx が依存する esbuild はネイティブバイナリを

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,39 +1,42 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'config:recommended',
-    // 新規に追加された GitHub Actions も自動でコミットSHA固定し、
-    // digest 更新を Renovate に管理させる
-    'helpers:pinGitHubActionDigests',
+    // 公式ベストプラクティス集。recommended + configMigration / pinDevDependencies /
+    // docker:pinDigests / pinGitHubActionDigests / security:minimumReleaseAgeNpm 等を内包。
+    'config:best-practices',
+    // 依存更新の commit を semantic (fix(deps) / chore(deps)) に強制する。
+    ':semanticCommits',
+    // schedule などの時刻基準を Asia/Tokyo にする。
+    ':timezone(Asia/Tokyo)',
   ],
-  dependencyDashboardApproval: false,
-  timezone: 'Asia/Tokyo',
-  schedule: ['before 10am on Monday'],
+  // 更新 PR を作成する時間帯。cron 5 フィールド(分は必ず `*`)。月・木の終日。
+  schedule: ['* * * * 1,4'],
+  // 同時にオープンする PR の上限。
+  prConcurrentLimit: 20,
+  // 時間あたり PR 作成数の上限を撤廃し、ウィンドウ内で一気に作成する。
+  prHourlyLimit: 0,
+  // 全 PR に付与するラベル。
+  labels: ['dependencies'],
+  // PR のレビュー/担当を固定する(リポ固有・保持)。
   reviewers: ['suzuryo'],
   assignees: ['suzuryo'],
-  prConcurrentLimit: 10,
-
-  // サプライチェーン攻撃対策:
-  // pnpm-workspace.yaml の minimumReleaseAge (= 3 日) より長く設定することで、
-  // Renovate が PR を作成する時点で公開から 4 日以上経過した状態になり、
-  // pnpm-lock.yaml 更新時の pnpm install が確実に解決できる (= バッファ)。
-  minimumReleaseAge: '4 days',
-  // cooldown 未経過の更新で PR / ブランチを作らせない
-  // (待機中の PR が先に作られる挙動を抑止する)
+  // cooldown 未経過の更新で PR / ブランチを作らせない(リポ固有・保持)。
   internalChecksFilter: 'strict',
-
-  // 週次でロックファイルを定期メンテナンス
-  lockFileMaintenance: {
-    enabled: true,
-    schedule: ['before 5am on monday'],
-  },
-
-  // 脆弱性修正は cooldown をバイパスして即時 PR 化する
+  // OSV データベースで脆弱性を検出する。
   osvVulnerabilityAlerts: true,
+  // 未解決の脆弱性をダッシュボードにサマリ表示する。
+  dependencyDashboardOSVVulnerabilitySummary: 'unresolved',
+  // 脆弱性修正は cooldown をバイパスして即時 PR 化する(リポ固有・保持)。
   vulnerabilityAlerts: {
     labels: ['security'],
   },
-
+  // 直接依存の更新がなくても lockfile 全体を定期リフレッシュし間接依存を更新する。
+  lockFileMaintenance: {
+    enabled: true,
+    // 実行する時間帯。月曜の終日。
+    schedule: ['* * * * 1'],
+  },
+  // commit type / label のマッピング(リポ固有・保持)。
   packageRules: [
     {
       matchManagers: ['npm'],


### PR DESCRIPTION
## 概要

Renovate 設定を共通の標準に揃える(複数リポ横展開)。

## 関連Issue/PR

- なし

## 変更内容

### Renovate (renovate.json5)
- config:recommended → config:best-practices に切替
- schedule を cron 化し毎週月曜 → 週2回(月・木 `* * * * 1,4`)に統一、lockFileMaintenance も cron 化(月曜)
- prConcurrentLimit: 20 / prHourlyLimit: 0 に統一
- dependencyDashboardOSVVulnerabilitySummary を追加(osvVulnerabilityAlerts は元から有効)
- 手動 minimumReleaseAge を security:minimumReleaseAgeNpm(npm 3日)に一本化
- reviewers / assignees / internalChecksFilter / vulnerabilityAlerts / packageRules(commit type マッピング)は保持

### pnpm (pnpm-workspace.yaml)
- minimumReleaseAge を 4320(3日)→ 2880(48h)に統一(allowBuilds は保持)

## レビュー観点

- pnpm 側の待機が 3 日 → 2 日にやや緩和される(標準統一による)。問題なければこのまま
- reviewers / vulnerabilityAlerts / packageRules が保持されているか

## 破壊的変更

なし。初回 Renovate 実行で devDependencies の pin / config 移行 PR が出る想定。

## テスト計画

- [ ] Renovate Dependency Dashboard が正常生成されること(マージ後)
- [ ] 月・木の想定どおりに PR が作成されること(マージ後)



