### PR TITLE
chore: renovateを月曜実行のみに変更し設定を最適化

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,18 +2,20 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     // 公式ベストプラクティス集。recommended + configMigration / pinDevDependencies /
-    // docker:pinDigests / pinGitHubActionDigests / security:minimumReleaseAgeNpm 等を内包。
+    // docker:pinDigests / pinGitHubActionDigests / security:minimumReleaseAgeNpm /
+    // group:monorepos 等を内包。
     'config:best-practices',
     // 依存更新の commit を semantic (fix(deps) / chore(deps)) に強制する。
     ':semanticCommits',
     // schedule などの時刻基準を Asia/Tokyo にする。
     ':timezone(Asia/Tokyo)',
   ],
-  // 更新 PR を作成する時間帯。cron 5 フィールド(分は必ず `*`)。月・木の終日。
-  schedule: ['* * * * 1,4'],
+  // 更新 PR を作成する曜日。cron 5 フィールド(分は必ず `*`)。月曜の終日のみ。
+  // 脆弱性修正 (vulnerabilityAlerts) はこの schedule を無視して即時 PR 化される。
+  schedule: ['* * * * 1'],
   // 同時にオープンする PR の上限。
   prConcurrentLimit: 20,
-  // 時間あたり PR 作成数の上限を撤廃し、ウィンドウ内で一気に作成する。
+  // 時間あたり PR 作成数の上限を撤廃し、月曜のウィンドウ内で一気に作成する。
   prHourlyLimit: 0,
   // 全 PR に付与するラベル。
   labels: ['dependencies'],
@@ -26,25 +28,36 @@
   osvVulnerabilityAlerts: true,
   // 未解決の脆弱性をダッシュボードにサマリ表示する。
   dependencyDashboardOSVVulnerabilitySummary: 'unresolved',
-  // 脆弱性修正は cooldown をバイパスして即時 PR 化する(リポ固有・保持)。
+  // 脆弱性修正は cooldown / schedule をバイパスして即時 PR 化する(リポ固有・保持)。
   vulnerabilityAlerts: {
     labels: ['security'],
   },
   // 直接依存の更新がなくても lockfile 全体を定期リフレッシュし間接依存を更新する。
   lockFileMaintenance: {
     enabled: true,
-    // 実行する時間帯。月曜の終日。
+    // 実行する時間帯。月曜の終日(本体 schedule とは独立に指定が必要)。
     schedule: ['* * * * 1'],
   },
-  // commit type / label のマッピング(リポ固有・保持)。
   packageRules: [
+    // メジャー以外 (minor/patch/digest) は manager を横断して 1 つの PR にまとめ、
+    // 月曜の通知を 1 本に集約する。github-actions の routine 更新もここに含まれ、
+    // commit type は chore に統一される。
+    {
+      matchUpdateTypes: ['minor', 'patch', 'digest', 'pinDigest'],
+      groupName: 'non-major dependencies',
+      semanticCommitType: 'chore',
+      labels: ['dependencies', 'automated'],
+    },
+    // メジャー更新は影響が大きいので manager 別に個別 PR とし、commit type / label を分ける。
     {
       matchManagers: ['npm'],
+      matchUpdateTypes: ['major'],
       labels: ['dependencies', 'automated'],
       semanticCommitType: 'chore',
     },
     {
       matchManagers: ['github-actions'],
+      matchUpdateTypes: ['major'],
       labels: ['github-actions', 'automated'],
       semanticCommitType: 'ci',
     },


### PR DESCRIPTION
## 概要

Renovate の更新 PR 作成を月曜のみに絞り、非メジャー更新を 1 PR に集約して通知ノイズを減らす。

## 関連Issue/PR

なし

## 変更内容

- 更新 PR の作成スケジュールを月・木 (`* * * * 1,4`) から **月曜終日のみ** (`* * * * 1`) に変更
- 非メジャー更新 (minor/patch/digest/pinDigest) を manager 横断で `non-major dependencies` の 1 PR に集約
- メジャー更新は影響が大きいため manager 別の個別 PR とし、commit type / label を従来どおり維持 (npm→`chore` / github-actions→`ci`)
- 脆弱性修正 (`vulnerabilityAlerts`) は `schedule` を無視して即時 PR 化される旨をコメントに明記
- `config:best-practices` に `group:monorepos` が含まれる旨をコメント追記

## レビュー観点

- **automerge は導入していない**（手動マージ運用を維持）。
- **トレードオフ**: 非メジャーを 1 PR に集約したことで、github-actions の routine 更新も本来の `ci(deps)` ではなくグループ統一の `chore(deps)` になります。「通知を 1 本に絞る」ための割り切りです。npm と github-actions を別グループ（週 2 PR）に分ける案も可能です。
- `lockFileMaintenance` の `schedule` は本体 `schedule` を継承しないため、別途 `* * * * 1`（月曜）を明示して維持しています。
- `renovate-config-validator` で検証済み（`Config validated successfully`）。

## 破壊的変更

なし

## テスト計画

- [ ] Renovate の Dependency Dashboard / 次回 PR が月曜のみに作成されることを確認
- [ ] 非メジャー更新が `non-major dependencies` の 1 PR にまとまることを確認
- [ ] メジャー更新が個別 PR として作成されることを確認