### PR TITLE
chore: markdownlint 設定を dotfiles の2ファイル体制に統一

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,8 @@
+{
+  // ルール本体は .markdownlint.json を参照する(dotfiles と統一)。
+  // ここではリント対象(globs)・除外(ignores)・カスタムルールのみ指定する。
+  "globs": ["**/*.md"],
+  // wiki 記法 [[...]] を禁止する共有カスタムルール(コード内は除外)
+  "customRules": ["./markdownlint-rules/no-wikilinks.cjs"],
+  "ignores": ["**/node_modules", ".git", "dist", "coverage"]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": { "line_length": 150, "code_blocks": false, "tables": false },
+  "MD055": { "style": "leading_and_trailing" }
+}

--- a/markdownlint-rules/no-wikilinks.cjs
+++ b/markdownlint-rules/no-wikilinks.cjs
@@ -1,0 +1,91 @@
+const wikiLinkPattern = /\[\[([^\]\n]+)\]\]/g
+
+const removeInlineCode = (line) => {
+  let result = ''
+  let index = 0
+
+  while (index < line.length) {
+    if (line[index] !== '`') {
+      result += line[index]
+      index += 1
+      continue
+    }
+
+    const start = index
+    while (index < line.length && line[index] === '`') {
+      index += 1
+    }
+
+    const tickCount = index - start
+    const delimiter = '`'.repeat(tickCount)
+    const end = line.indexOf(delimiter, index)
+
+    if (end === -1) {
+      result += line.slice(start)
+      break
+    }
+
+    result += ' '.repeat(end + tickCount - start)
+    index = end + tickCount
+  }
+
+  return result
+}
+
+const findFenceMarker = (line) => {
+  const match = /^( {0,3})(`{3,}|~{3,})/.exec(line)
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    char: match[2][0],
+    length: match[2].length,
+  }
+}
+
+module.exports = {
+  names: ['no-wikilinks'],
+  description: 'Wiki-style links are not GitHub Flavored Markdown',
+  tags: ['links', 'gfm'],
+  parser: 'none',
+  function: (params, onError) => {
+    let fence = null
+
+    params.lines.forEach((line, lineIndex) => {
+      const marker = findFenceMarker(line)
+
+      if (marker) {
+        if (
+          fence &&
+          marker.char === fence.char &&
+          marker.length >= fence.length
+        ) {
+          fence = null
+        } else if (!fence) {
+          fence = marker
+        }
+
+        return
+      }
+
+      if (fence) {
+        return
+      }
+
+      const searchableLine = removeInlineCode(line)
+      const matches = searchableLine.matchAll(wikiLinkPattern)
+
+      for (const match of matches) {
+        onError({
+          lineNumber: lineIndex + 1,
+          detail:
+            'Use a normal Markdown link for documents or a code span for skill/memory names.',
+          context: match[0],
+          range: [match.index + 1, match[0].length],
+        })
+      }
+    })
+  },
+}


### PR DESCRIPTION
## 概要

markdownlint 設定を dotfiles 標準の2ファイル体制へ新規導入する。

## 変更内容

- `.markdownlint.json`（ルール本体）と `.markdownlint-cli2.jsonc`（対象・除外・カスタムルール）を追加
- `MD013: line_length 150`（`code_blocks` / `tables` は除外）/ `MD055: leading_and_trailing`
- 共有カスタムルール `no-wikilinks` を追加

## 確認

- `markdownlint-cli2` で 9 ファイル green（既存の markdown に違反なし）